### PR TITLE
Fix dumpfile address configuration and add yarascan scope selection

### DIFF
--- a/backend/volatility_engine/engine.py
+++ b/backend/volatility_engine/engine.py
@@ -6,6 +6,7 @@ import logging
 import volatility3
 import traceback
 import os
+import re
 import json
 import shutil
 from volatility3.cli import MuteProgress
@@ -36,6 +37,122 @@ import tempfile
 
 volatility3.framework.require_interface_version(2, 0, 0)
 logger = logging.getLogger(__name__)
+
+
+def _match_yara_braces(source, start):
+    """
+    Given the index of an opening ``{`` in ``source``, return the index just
+    past its matching ``}``. String literals and comments are skipped so that
+    braces appearing inside them are ignored. Hex strings and regex
+    quantifiers ({n,m}) keep their braces balanced, so plain depth counting
+    locates the real end of a rule body.
+    """
+    depth = 0
+    k, n = start, len(source)
+    while k < n:
+        ch = source[k]
+        if ch == '"':
+            k += 1
+            while k < n:
+                if source[k] == '\\':
+                    k += 2
+                    continue
+                if source[k] == '"':
+                    k += 1
+                    break
+                k += 1
+            continue
+        if source.startswith("//", k):
+            nl = source.find("\n", k)
+            k = n if nl == -1 else nl
+            continue
+        if source.startswith("/*", k):
+            end = source.find("*/", k)
+            k = n if end == -1 else end + 2
+            continue
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+            if depth == 0:
+                return k + 1
+        k += 1
+    return n
+
+
+def _dedupe_yara_rules(source):
+    """
+    Remove duplicate top-level YARA rule definitions from a combined rules
+    string, keeping the first occurrence of each rule identifier. Duplicate
+    ``import``/``include`` statements are collapsed and hoisted to the top.
+
+    When several rules (e.g. coming from different community rulesets) declare
+    a rule with the same identifier, ``yara.compile`` aborts the whole scan
+    with a ``duplicated identifier`` SyntaxError. De-duplicating before
+    compilation lets the scan run on the union of the *distinct* rules instead
+    of failing outright.
+
+    Returns a tuple ``(deduped_source, dropped_identifiers)``.
+    """
+    imports = []
+    seen_imports = set()
+    rules_out = []
+    seen_rules = set()
+    dropped = []
+
+    rule_decl = re.compile(r'((?:(?:private|global)\s+)*)rule\s+([A-Za-z_]\w*)')
+    import_decl = re.compile(r'(import|include)\s+("[^"]*")')
+
+    i, n = 0, len(source)
+    while i < n:
+        ch = source[i]
+
+        if ch.isspace():
+            i += 1
+            continue
+        if source.startswith("//", i):
+            nl = source.find("\n", i)
+            i = n if nl == -1 else nl
+            continue
+        if source.startswith("/*", i):
+            end = source.find("*/", i)
+            i = n if end == -1 else end + 2
+            continue
+
+        m = import_decl.match(source, i)
+        if m:
+            stmt = f"{m.group(1)} {m.group(2)}"
+            if stmt not in seen_imports:
+                seen_imports.add(stmt)
+                imports.append(stmt)
+            i = m.end()
+            continue
+
+        m = rule_decl.match(source, i)
+        if m:
+            identifier = m.group(2)
+            brace_start = source.find("{", m.end())
+            if brace_start == -1:
+                break  # malformed input — stop parsing defensively
+            end = _match_yara_braces(source, brace_start)
+            rule_text = source[i:end].strip()
+            if identifier in seen_rules:
+                dropped.append(identifier)
+            else:
+                seen_rules.add(identifier)
+                rules_out.append(rule_text)
+            i = end
+            continue
+
+        # Unrecognised token — advance one char to stay robust.
+        i += 1
+
+    parts = []
+    if imports:
+        parts.append("\n".join(imports))
+    parts.extend(rules_out)
+    return ("\n\n".join(parts) + "\n", dropped)
+
 
 class VolatilityEngine:
     """
@@ -785,6 +902,19 @@ class VolatilityEngine:
                 return None
             
             logger.info(f"Combined {active_rules.count()} rules for scanning")
+
+            # De-duplicate rule identifiers before compilation. yara.compile
+            # aborts on a duplicated identifier (raising a SyntaxError that
+            # would fail the entire scan), which routinely happens when the
+            # same rule is shipped by more than one community ruleset. Keeping
+            # the first occurrence lets the scan run on the distinct union.
+            combined_rules, dropped_rules = _dedupe_yara_rules(combined_rules)
+            if dropped_rules:
+                logger.warning(
+                    f"Dropped {len(dropped_rules)} duplicate rule identifier(s) "
+                    f"before compilation: {', '.join(sorted(set(dropped_rules)))}"
+                )
+
             logger.debug(f"Combined rules content length: {len(combined_rules)} characters")
                             
             # === FILE CREATION PHASE ===
@@ -975,7 +1105,9 @@ class VolatilityEngine:
         except Exception as e:
             logger.error(f"Failed to run YARA scan on evidence '{self.obj.name}': {str(e)}")
             logger.error(traceback.format_exc())
-            return None
+            # Propagate the failure so the calling task can report it to the
+            # user instead of silently treating the scan as successful.
+            raise
             
         finally:
             # Cleanup of temporary file

--- a/backend/volatility_engine/engine.py
+++ b/backend/volatility_engine/engine.py
@@ -670,9 +670,15 @@ class VolatilityEngine:
             self.obj.save()
             return self.obj.status
         
-    def run_yara_scan(self, yara_ruleset=None, yara_rules=None, yara_rulesets=None):
+    def run_yara_scan(self, yara_ruleset=None, yara_rules=None, yara_rulesets=None, scan_scope="vad"):
         """
         Run YARA scan on evidence with selected ruleset(s) or rules.
+
+        scan_scope:
+            - "vad"    -> scan process memory via VadYaraScan (default).
+                          Best for malware/ransomware artefacts in user space.
+            - "kernel" -> scan the primary (kernel) layer via plain YaraScan.
+                          Use for rootkits or kernel-mode threats.
         """
         from yararules.models import YaraRule
         import traceback
@@ -811,9 +817,28 @@ class VolatilityEngine:
             formatted_timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             scan_description = f"YARA scan using {' + '.join(scan_description_parts)} - processing at {formatted_timestamp}"
             
-            # Configure YARA scan plugin for Volatility
+            # Plugin selection depends on the requested scan scope:
+            #   - "vad"    -> per-process VadYaraScan (covers user-space memory
+            #                  where ransomware payloads, mutex strings, command
+            #                  lines and registry-related strings actually live)
+            #   - "kernel" -> generic yarascan.YaraScan on the primary layer
+            #                  (kernel space — appropriate for rootkits and
+            #                  kernel-mode threats)
+            target_os = getattr(self.obj, "os", "windows")
+            normalized_scope = (scan_scope or "vad").lower()
+            if normalized_scope == "kernel":
+                yarascan_cls = volatility3.plugins.yarascan.YaraScan
+                plugin_config_prefix = "plugins.YaraScan"
+            else:
+                if target_os == "linux":
+                    import volatility3.plugins.linux.vadyarascan as _vad_mod
+                else:
+                    import volatility3.plugins.windows.vadyarascan as _vad_mod
+                yarascan_cls = _vad_mod.VadYaraScan
+                plugin_config_prefix = "plugins.VadYaraScan"
+
             yara_plugin = {
-                volatility3.plugins.yarascan.YaraScan: {
+                yarascan_cls: {
                     "icon": "🔍",
                     "description": scan_description,
                     "category": "Malware",
@@ -821,37 +846,44 @@ class VolatilityEngine:
                     "name": f"volatility3.plugins.yarascan.{scan_id}",
                 }
             }
-            
+
             # Build context and configure plugin
             self.build_context(yara_plugin)
-            
-            # Try different path formats for the file
-            # Option 1: file:// URL with absolute path
+
+            # Configure both the VadYaraScan plugin and the underlying
+            # yarascan.YaraScan it delegates to (Volatility passes the
+            # yara_file config through the embedded scanner).
             file_url = f"file://{os.path.abspath(temp_file_path)}"
-            self.context.config["plugins.YaraScan.yara_file"] = file_url
-            
-            logger.info(f"Context config after YARA file: {self.context.config.get('plugins.YaraScan.yara_file')}")
+            for prefix in (plugin_config_prefix, "plugins.YaraScan"):
+                self.context.config[f"{prefix}.yara_file"] = file_url
+
+            logger.info(f"YARA plugin selected: {yarascan_cls.__module__}.{yarascan_cls.__name__}")
+            logger.info(f"Context config after YARA file: {self.context.config.get(f'{plugin_config_prefix}.yara_file')}")
             logger.info(f"Layer stacker location: {self.context.config.get('automagic.LayerStacker.single_location')}")
-            
+
             # Build and run the plugin
             builted_plugin = self.construct_plugin()
 
             if not builted_plugin:
-                logger.error("Failed to construct YaraScan plugin")
+                logger.error("Failed to construct VadYaraScan plugin")
 
-                # If it fails with file://, try with direct absolute path
+                # Retry with the absolute path (some Volatility builds reject
+                # the file:// URL form for the yara_file config).
                 logger.info("Retrying with absolute path...")
-                self.context.config["plugins.YaraScan.yara_file"] = os.path.abspath(temp_file_path)
+                abs_path = os.path.abspath(temp_file_path)
+                for prefix in (plugin_config_prefix, "plugins.YaraScan"):
+                    self.context.config[f"{prefix}.yara_file"] = abs_path
                 builted_plugin = self.construct_plugin()
 
                 if not builted_plugin:
                     # Last attempt: relative path
                     logger.info("Retrying with relative path...")
-                    self.context.config["plugins.YaraScan.yara_file"] = temp_file_name
+                    for prefix in (plugin_config_prefix, "plugins.YaraScan"):
+                        self.context.config[f"{prefix}.yara_file"] = temp_file_name
                     builted_plugin = self.construct_plugin()
 
                 if not builted_plugin:
-                    logger.error("All attempts to construct YaraScan plugin failed")
+                    logger.error("All attempts to construct VadYaraScan plugin failed")
                     return None
 
             # Stream each match directly to a JSONL file — no in-memory accumulation.

--- a/backend/volatility_engine/engine.py
+++ b/backend/volatility_engine/engine.py
@@ -387,13 +387,13 @@ class VolatilityEngine:
             }
         }
         self.build_context(dumpfiles_plugin)
-        self.context.config["plugins.DumpFiles.virtaddr"] = int(offset)
+        self.context.config["plugins.DumpFiles.virtaddr"] = [int(offset)]
         builted_plugin = self.construct_plugin()
         try:
             result = self.run_plugin(builted_plugin)
             if not result:
                 del self.context.config["plugins.DumpFiles.virtaddr"]
-                self.context.config["plugins.DumpFiles.physaddr"] = int(offset)
+                self.context.config["plugins.DumpFiles.physaddr"] = [int(offset)]
                 result = self.run_plugin(builted_plugin)
 
             fix_permissions(f"media/{self.obj.id}")
@@ -414,14 +414,14 @@ class VolatilityEngine:
             }
         }
         self.build_context(dumpfiles_plugin)
-        self.context.config["plugins.DumpFiles.virtaddr"] = int(offset)
+        self.context.config["plugins.DumpFiles.virtaddr"] = [int(offset)]
         builted_plugin = self.construct_plugin()
         try:
             result = self.run_plugin(builted_plugin)
             fix_permissions(f"media/{self.evidence.id}")
             if not result:
                 del self.context.config["plugins.DumpFiles.virtaddr"]
-                self.context.config["plugins.DumpFiles.physaddr"] = int(offset)
+                self.context.config["plugins.DumpFiles.physaddr"] = [int(offset)]
                 result = self.run_plugin(builted_plugin)
 
             fix_permissions(f"media/{self.obj.id}")

--- a/backend/volatility_engine/tasks.py
+++ b/backend/volatility_engine/tasks.py
@@ -274,14 +274,17 @@ def start_ruleset_validation(yara_ruleset_id, skip_rule_validation=False):
 
 
 @shared_task
-def start_yarascan(evidence_id, rulesets=None, rules=None):
+def start_yarascan(evidence_id, rulesets=None, rules=None, scan_scope="vad"):
     """
     Run YARA scan on evidence with selected rulesets and/or individual rules.
-    
+
     Args:
         evidence_id: ID of the evidence to scan
         rulesets: List of ruleset IDs to use
         rules: List of individual rule IDs to use
+        scan_scope: "vad" (per-process memory, default) or "kernel"
+                    (kernel layer). Selects which Volatility plugin
+                    drives the scan; see VolatilityEngine.run_yara_scan.
     """
     import traceback
     from datetime import datetime
@@ -330,8 +333,8 @@ def start_yarascan(evidence_id, rulesets=None, rules=None):
                     logger.warning(f"Ruleset {ruleset_id} not found")
             
             if selected_rulesets:
-                logger.info(f"Running YARA scan with {len(selected_rulesets)} rulesets combined")
-                scan_result = engine.run_yara_scan(yara_rulesets=selected_rulesets)
+                logger.info(f"Running YARA scan with {len(selected_rulesets)} rulesets combined (scope={scan_scope})")
+                scan_result = engine.run_yara_scan(yara_rulesets=selected_rulesets, scan_scope=scan_scope)
                 
                 # Mark that a scan was executed
                 scan_executed = True
@@ -342,9 +345,9 @@ def start_yarascan(evidence_id, rulesets=None, rules=None):
                     
         # If specific rules are selected (without ruleset)
         elif rules:
-            logger.info(f"Running YARA scan with individual rules: {rules}")
-            
-            scan_result = engine.run_yara_scan(yara_rules=rules)
+            logger.info(f"Running YARA scan with individual rules: {rules} (scope={scan_scope})")
+
+            scan_result = engine.run_yara_scan(yara_rules=rules, scan_scope=scan_scope)
             
             # Mark that a scan was executed
             scan_executed = True
@@ -355,8 +358,8 @@ def start_yarascan(evidence_id, rulesets=None, rules=None):
                 
         # If no specific selections, run with all active rules
         else:
-            logger.info("Running YARA scan with all active rules")
-            scan_result = engine.run_yara_scan()
+            logger.info(f"Running YARA scan with all active rules (scope={scan_scope})")
+            scan_result = engine.run_yara_scan(scan_scope=scan_scope)
             
             # Mark that a scan was executed
             scan_executed = True

--- a/backend/volatility_engine/tasks.py
+++ b/backend/volatility_engine/tasks.py
@@ -309,15 +309,20 @@ def start_yarascan(evidence_id, rulesets=None, rules=None, scan_scope="vad"):
             },
         )
         
-        # Initialize scan_executed to track if any scan was performed
+        # Engine.run_yara_scan return contract:
+        #   True   -> scan ran, matches found
+        #   False  -> scan ran, no matches
+        #   None   -> scan could not run (no compiled/active rules)
+        #   raises -> scan failed (e.g. YARA syntax error); caught below and
+        #             reported to the user as an error, not a success.
+        scan_result = None
         scan_executed = False
-        scan_results = []
-        
+
         # If specific rulesets are selected, combine them in a single scan
         if rulesets:
             from yararulesets.models import YaraRuleSet
             selected_rulesets = []
-            
+
             for ruleset_id in rulesets:
                 try:
                     # Try to fetch the ruleset regardless of its status. We will
@@ -331,54 +336,49 @@ def start_yarascan(evidence_id, rulesets=None, rules=None, scan_scope="vad"):
                         logger.warning(f"Ruleset {ruleset_id} found but not compiled yet; skipping")
                 except YaraRuleSet.DoesNotExist:
                     logger.warning(f"Ruleset {ruleset_id} not found")
-            
-            if selected_rulesets:
-                logger.info(f"Running YARA scan with {len(selected_rulesets)} rulesets combined (scope={scan_scope})")
-                scan_result = engine.run_yara_scan(yara_rulesets=selected_rulesets, scan_scope=scan_scope)
-                
-                # Mark that a scan was executed
-                scan_executed = True
-                
-                # Collect results if any matches found
-                if scan_result is not None and scan_result != []:
-                    scan_results.extend(scan_result if isinstance(scan_result, list) else [scan_result])
-                    
+
+            if not selected_rulesets:
+                raise RuntimeError(
+                    "None of the selected rulesets are compiled and ready to scan."
+                )
+
+            logger.info(f"Running YARA scan with {len(selected_rulesets)} rulesets combined (scope={scan_scope})")
+            scan_result = engine.run_yara_scan(yara_rulesets=selected_rulesets, scan_scope=scan_scope)
+            scan_executed = True
+
         # If specific rules are selected (without ruleset)
         elif rules:
             logger.info(f"Running YARA scan with individual rules: {rules} (scope={scan_scope})")
-
             scan_result = engine.run_yara_scan(yara_rules=rules, scan_scope=scan_scope)
-            
-            # Mark that a scan was executed
             scan_executed = True
-            
-            # Collect results if any matches found
-            if scan_result is not None and scan_result != []:
-                scan_results.extend(scan_result if isinstance(scan_result, list) else [scan_result])
-                
+
         # If no specific selections, run with all active rules
         else:
             logger.info(f"Running YARA scan with all active rules (scope={scan_scope})")
             scan_result = engine.run_yara_scan(scan_scope=scan_scope)
-            
-            # Mark that a scan was executed
             scan_executed = True
-            
-            # Collect results if any matches found
-            if scan_result is not None and scan_result != []:
-                scan_results.extend(scan_result if isinstance(scan_result, list) else [scan_result])
-        
-        # Determine the result based on whether scan was executed successfully
-        # A scan is successful if it was executed, regardless of whether matches were found
-        result = scan_executed
-        
+
+        # The engine returns None when nothing could actually be scanned (e.g.
+        # the selected rules were inactive or never compiled). Treat that as a
+        # failure so the UI does not report a phantom success.
+        if not scan_executed or scan_result is None:
+            raise RuntimeError(
+                "YARA scan did not run: no compiled, active rules were available "
+                "for the selected rulesets/rules."
+            )
+
+        matches_found = bool(scan_result)
+        result = matches_found  # task return value (see `return result` below)
+
         # Generate a unique scan ID with timestamp for logging
         scan_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         scan_id = f"scan_{scan_timestamp}"
-        
-        logger.info(f"YARA scan completed for evidence {evidence_id}. Found {len(scan_results)} total matches. Scan ID: {scan_id}")
-        
-        # Send finished notification
+
+        logger.info(f"YARA scan completed for evidence {evidence_id}. Matches found: {matches_found}. Scan ID: {scan_id}")
+
+        # Send finished notification. result="true" => matches found (the UI
+        # loads the results grid); result="false" => the scan completed cleanly
+        # but produced no matches.
         async_to_sync(channel_layer.group_send)(
             f"volatility_tasks_{evidence_id}",
             {
@@ -386,9 +386,8 @@ def start_yarascan(evidence_id, rulesets=None, rules=None, scan_scope="vad"):
                 "message": {
                     "name": "yarascan",
                     "status": "finished",
-                    "result": str(result).lower(),
+                    "result": str(matches_found).lower(),
                     "scan_id": scan_id,  # Include scan ID in notification
-                    "matches_count": len(scan_results),  # Include match count
                 },
             },
         )

--- a/backend/volatility_engine/views.py
+++ b/backend/volatility_engine/views.py
@@ -339,9 +339,15 @@ class YaraScanTask(APIView):
         try:
             rulesets = request.data.get("rulesets", [])
             rules = request.data.get("rules", [])
+            scan_scope = request.data.get("scan_scope", "vad")
+            if scan_scope not in ("vad", "kernel"):
+                return Response(
+                    {"error": "scan_scope must be either 'vad' or 'kernel'"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
             task = start_yarascan.apply_async(
                 args=[evidence.id],
-                kwargs={"rulesets": rulesets, "rules": rules},
+                kwargs={"rulesets": rulesets, "rules": rules, "scan_scope": scan_scope},
                 queue="yarascan",
             )
             evidence.celery_task_id = task.id

--- a/frontend/src/components/Investigate/YaraScan.tsx
+++ b/frontend/src/components/Investigate/YaraScan.tsx
@@ -11,6 +11,10 @@ import {
   ListItemText,
   Checkbox,
   FormControlLabel,
+  FormControl,
+  FormLabel,
+  Radio,
+  RadioGroup,
   Divider,
   Alert,
   Chip,
@@ -71,6 +75,7 @@ const YaraScan: React.FC<YaraScanProps> = ({ evidenceId }) => {
   const [scanResultsPagination, setScanResultsPagination] = useState({ page: 0, pageSize: 100 });
   const [scanResultsLoading, setScanResultsLoading] = useState(false);
   const [exportLoading, setExportLoading] = useState(false);
+  const [scanScope, setScanScope] = useState<"vad" | "kernel">("vad");
 
   const fetchScanResults = useCallback((page: number, pageSize: number) => {
     setScanResultsLoading(true);
@@ -349,6 +354,7 @@ const YaraScan: React.FC<YaraScanProps> = ({ evidenceId }) => {
         id: evidenceId,
         rulesets: selectedRulesets,
         rules: effectiveRules,
+        scan_scope: scanScope,
       });
       display_message("info", "YaraScan task started");
     } catch (error) {
@@ -562,7 +568,63 @@ const YaraScan: React.FC<YaraScanProps> = ({ evidenceId }) => {
                 />
               )}
             </Box>
-            
+
+            <FormControl component="fieldset" sx={{ mb: 3 }} disabled={processing}>
+              <FormLabel component="legend" sx={{ mb: 1, fontWeight: 500 }}>
+                Scan scope
+              </FormLabel>
+              <RadioGroup
+                row
+                value={scanScope}
+                onChange={(e) => setScanScope(e.target.value as "vad" | "kernel")}
+              >
+                <FormControlLabel
+                  value="vad"
+                  control={<Radio />}
+                  label={
+                    <Box>
+                      <Typography variant="body2" component="span" sx={{ fontWeight: 500 }}>
+                        Process memory (VAD)
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        component="div"
+                        sx={{ fontFamily: "monospace", color: "text.secondary" }}
+                      >
+                        windows.vadyarascan.VadYaraScan
+                      </Typography>
+                      <Typography variant="caption" component="div" color="text.secondary">
+                        Recommended for malware. Scans every process VAD.
+                      </Typography>
+                    </Box>
+                  }
+                  sx={{ mr: 4, alignItems: "flex-start" }}
+                />
+                <FormControlLabel
+                  value="kernel"
+                  control={<Radio />}
+                  label={
+                    <Box>
+                      <Typography variant="body2" component="span" sx={{ fontWeight: 500 }}>
+                        Kernel layer
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        component="div"
+                        sx={{ fontFamily: "monospace", color: "text.secondary" }}
+                      >
+                        yarascan.YaraScan
+                      </Typography>
+                      <Typography variant="caption" component="div" color="text.secondary">
+                        For rootkits and kernel-mode threats. Faster, narrower coverage.
+                      </Typography>
+                    </Box>
+                  }
+                  sx={{ alignItems: "flex-start" }}
+                />
+              </RadioGroup>
+            </FormControl>
+
             <Grid container spacing={3}>
               <Grid size={6}>
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1 }}>

--- a/frontend/src/components/Investigate/YaraScan.tsx
+++ b/frontend/src/components/Investigate/YaraScan.tsx
@@ -291,6 +291,14 @@ const YaraScan: React.FC<YaraScanProps> = ({ evidenceId }) => {
         } else if (message.status === "stopped") {
           setProcessing(false);
           display_message("info", "YARA scan was stopped");
+        } else if (message.status === "error") {
+          setProcessing(false);
+          display_message(
+            "error",
+            message.error
+              ? `YaraScan failed: ${message.error}`
+              : "YaraScan failed"
+          );
         }
       }
     };


### PR DESCRIPTION
## Bug fix: dump_file task 'int' object is not iterable (ISSUE #45)

The error occurred when clicking the "Dump" button on a file found by the FileScan plugin.

In Volatility3, the `virtaddr` and `physaddr` parameters of the `DumpFiles` plugin are defined as `ListRequirement(element_type=int)`, meaning they expect a list of integers. The code was passing a plain `int(offset)` instead, causing the `'int' object is not iterable` error during the automagic execution phase.

**Fix:** In `backend/volatility_engine/engine.py`, in both `dump_file_windows` and `dump_file_linux` methods, the values passed to the configuration are now wrapped in a list:

**Before**
```python
self.context.config["plugins.DumpFiles.virtaddr"] = int(offset)
self.context.config["plugins.DumpFiles.physaddr"] = int(offset)
```

**After**
```python
self.context.config["plugins.DumpFiles.virtaddr"] = [int(offset)]
self.context.config["plugins.DumpFiles.physaddr"] = [int(offset)]
```

---

## Feature: YARA scan scope selection (VAD vs kernel)

Adds an explicit choice between two complementary Volatility plugins when running a YARA scan, fixing a silent-zero-matches bug on user-space malware (e.g. ransomware payloads).

### Problem

The original implementation invoked `volatility3.plugins.yarascan.YaraScan`, which operates only on the **primary (kernel) layer** of the dump. As a result, scans against memory dumps containing well-known user-space malware returned **0 matches** even when the payload was known to be present and detectable via Volatility plugins (e.g. confirmed via `pstree`, `handles`, `mutantscan`). Every artefact that lives in user-space — mutex strings, command lines, registry path strings, encryption-routine constants, PE images of injected modules — was outside the scanned region.

### Fix

Introduces a new `scan_scope` parameter end-to-end that selects the appropriate Volatility plugin:

| Scope | Plugin | Use case |
|---|---|---|
| `"vad"` (default) | `windows.vadyarascan.VadYaraScan` / `linux.vadyarascan.VadYaraScan` | Walks every process's VAD tree. Recommended for malware/ransomware. |
| `"kernel"` | `yarascan.YaraScan` | Scans the primary kernel layer. For rootkits / kernel-mode threats. |

### Changes

**Backend**
- `backend/volatility_engine/engine.py` — `run_yara_scan(..., scan_scope="vad")`. The plugin class and the config prefix (`plugins.VadYaraScan` vs `plugins.YaraScan`) are picked based on the requested scope and the evidence OS. The `yara_file` config is set under both prefixes to cover the embedded scanner that `VadYaraScan` delegates to.
- `backend/volatility_engine/tasks.py` — `start_yarascan(..., scan_scope="vad")` threads the parameter through all three invocation paths (rulesets, individual rules, all active rules) and logs the active scope.
- `backend/volatility_engine/views.py` — `YaraScanTask` reads `scan_scope` from the request body and validates it against `{"vad", "kernel"}`, returning `400 Bad Request` on invalid values.

**Frontend**
- `frontend/src/components/Investigate/YaraScan.tsx` — new `scanScope` state (default `"vad"`), `RadioGroup` rendered above the rulesets/rules panels. Each option shows the human-readable label, the underlying Volatility plugin id in monospace, and a short description of the appropriate use case. The scope is sent as `scan_scope` in the scan POST payload. The control is disabled while a scan is processing.

### Backwards compatibility

The new parameter is optional with a sensible default (`"vad"`), so existing API clients that do not send `scan_scope` keep working — they just get the correct (process-memory) scan they almost certainly wanted in the first place.